### PR TITLE
Add worker to Docker Compose and Makefile for task automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+.PHONY: setup up down logs reload monitor bash test migrate tinker queue
+
+setup:
+	@if [ ! -f .env ]; then cp .env.example .env; fi
+	@docker compose up -d --build
+	@docker compose exec app composer install
+	@docker compose exec app php artisan key:generate
+	@docker compose exec app php artisan migrate --seed
+	@echo "Ambiente configurado e rodando!"
+
+up:
+	@docker compose up -d
+
+down:
+	@docker compose down
+
+logs:
+	@docker compose logs -f app
+
+reload:
+	@docker compose exec app php artisan octane:reload
+
+monitor:
+	@docker compose exec app php artisan octane:status
+
+bash:
+	@docker compose exec app bash
+
+test:
+	@docker compose exec app php artisan test
+
+migrate:
+	@docker compose exec app php artisan migrate
+
+tinker:
+	@docker compose exec app php artisan tinker
+
+queue:
+	@docker compose exec app php artisan queue:work

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,24 @@ services:
     networks:
       - simplify_network
 
+  worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: simplify_worker
+    restart: unless-stopped
+    working_dir: /var/www
+    volumes:
+      - .:/var/www
+    command: php artisan queue:work --tries=3
+    depends_on:
+      app:
+        condition: service_started
+      redis:
+        condition: service_started
+    networks:
+      - simplify_network
+
   db:
     image: postgres:16-alpine
     container_name: simplify_db


### PR DESCRIPTION
## Summary

This pull request introduces a `worker` service to the `docker-compose.yml`, enabling the execution of task queues using `php artisan queue:work`. A `Makefile` is also added, providing commands for automated environment setup and management, such as `setup`, `up`, `down`, `logs`, and `migrate`.

## Changes

- Added `worker` service to `docker-compose.yml`.
- Included a `Makefile` with convenient commands for development automation.
- Improved organization and simplicity in environment management.

## Related Issues/Notes

Closes #9 


## Checklist

- [x] Tests are included (if applicable).
- [x] Documentation is updated (if needed).
- [x] Changes adhere to coding standards.
```