### PR TITLE
Adjust transaction timestamps in database migration

### DIFF
--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -13,8 +13,6 @@ class Transaction extends Model
 {
     use HasFactory, HasUuids;
 
-    public const null UPDATED_AT = null;
-
     protected $fillable = [
         'payer_wallet_id',
         'payee_wallet_id',

--- a/database/migrations/2026_01_17_002905_create_transactions_table.php
+++ b/database/migrations/2026_01_17_002905_create_transactions_table.php
@@ -16,7 +16,8 @@ return new class extends Migration
             $table->foreignUuid('payer_wallet_id')->constrained('wallets');
             $table->foreignUuid('payee_wallet_id')->constrained('wallets');
             $table->decimal('amount', 10, 2);
-            $table->timestamp('created_at')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->useCurrent();
         });
     }
 


### PR DESCRIPTION

### Description?

This pull request adjusts the timestamps in the `transactions` table:
- Changes `created_at` and `updated_at` columns to use the `useCurrent` method in their migration.
- Removes `UPDATED_AT` from the `Transaction` model to align with Eloquent's default behavior.

### Why is this change necessary?

- Ensures consistency with Laravel's default timestamp handling.
- Simplifies and standardizes the application code by reducing custom declarations.

### Related Issues/Notes

Closes #20

### Checklist

- [x] Tests added to cover changes (if applicable)
- [x] Documentation updated (if applicable)
- [x] Code style and formatting verified
```